### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To expand upon the core learning modules please check out the learning objective
 
 - :scream_cat: [SQL](modules/supplementary/SQL.md)
 - :computer: [Terraform](modules/supplementary/Terraform.md)
-- :floppy_disk: [Databases](modules/supplementary/Database.md)
+- :floppy_disk: [Databases](modules/supplementary/Databases.md)
 
 
 ## Contributing to data-101


### PR DESCRIPTION
repaired broken Databases Link as it was not resolving to the correct page, giving error 404. It was missing 's' at the end of the url Old link point to --> https://github.com/madetech/data-101/blob/main/modules/supplementary/Database.md The 'madetech/data-101' repository doesn't contain the 'modules/supplementary/Database.md' path in 'main'.   The correct folder should point to Databases.md