### PR TITLE
Readme review and move intro content to own page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,12 @@
 ## Data Learning Paths
 
-Please check out below the Data Learning Paths!
+Below you can find several sets of curated learning resources organised in Data Learning Paths. Concepts are split from beginner to advanced to aid your self-paced development. 
 
-These are split to beginner -> advanced data concepts to aid in self development.
+Please bear in mind that some of the resources were selected and added here a considerable time ago. If you have reasons to believe a resource is outdated please feel free to reach out to more senior members of the team to confirm if they are still relevant. Whenever outdated and no longer relevant resources are identified please take the time to review this repo and send a PR suggesting your updates.
 
-- :sparkle: [Data 101 Learning Objectives](data_learning_paths/data_101.md)
-- :mechanical_arm: [Data 102 Learning Objectives](data_learning_paths/data_102.md)
-- :crystal_ball: [Data 103 Learning Objectives](data_learning_paths/data_103.md)
-- :floppy_disk: [Cert paths](data_learning_paths/certs.md)
-
-If you are interested in learning about data science we have provided the following document containing useful topics and resources to get you started:
-
-# Data-101: An introduction to big data in Made Tech (basic tutorial)
-
-Welcome to the data-101 intro section!
-
-You can find the core learning path below to introduce you to some core data engineering concepts, this is a series of concise modules aiming to take an engineer with no data experience to feeling competent when presented with a data focussed project.
-
-To expand upon the core learning modules please check out the learning objectives folder where you can see some of the key learning objectives for each data engineer level, and resources to help you achieve those learning objectives.
-
-![Learning pathway diagram](https://github.com/madetech/data-101/blob/main/images/learningpathway.png?raw=true)
-
-# Core
-
-## Python
- - :snake: [Python, pip, pyenv](modules/core/Python.md)
- - :satellite: [API Frameworks - Flask, fastAPI, Django](modules/core/ApiFrameworks.md)
-
-### Modules
- - :panda_face: [Pandas - Introduction to data loading & transformations](modules/core/Python%20modules/Pandas.md)
- - :earth_africa: [GeoPandas - Plotting spatial data](modules/core/Python%20modules/geopandas.md)
-
-## Spark
- - :sparkler: [Spark - Putting the **big** in *big data*](modules/core/Spark.md)
-
-
-# Supplementary learning
-
-- :scream_cat: [SQL](modules/supplementary/SQL.md)
-- :computer: [Terraform](modules/supplementary/Terraform.md)
-- :floppy_disk: [Databases](modules/supplementary/Databases.md)
-
-# Guides
- - :robot: [Machine Learning Workflow: A guide for DMs](guides/machine_learning_workflow.md)
- - :book: [Juypter Notebook Setup](guides/jupyter_setup.md)
- - :pencil: [List of tooling](guides/tooling.md)
- - :cat2: [Sphinx setup instructions](guides/sphinx_setup.md)
- - :memo: [AWS Glue Features](guides/AWS_Glue_Features.md)
- - :guardsman: [AWS TF Permissions](guides/aws_tf_permissions.md)
- - :bookmark: [Poetry with Pyenv](guides/pyenv.md) 
-
-
-## Contributing to data-101
-We welcome and encourage all contributions! This resource is built by the COP-data community for the COP-data community.
-Please submit contributions via pull request.
-Any questions can be posted to [COP-data](https://madetechteam.slack.com/archives/C01PTEPED6G)
+- :sparkle: [Data 101 Core Intro](data_learning_paths/data_101_core.md)
+- :sparkle: [Data 101 Learning Path](data_learning_paths/data_101.md)
+- :mechanical_arm: [Data 102 Learning Path](data_learning_paths/data_102.md)
+- :crystal_ball: [Data 103 Learning Path](data_learning_paths/data_103.md)
+- :floppy_disk: [Recommended Certifications](https://sites.google.com/madetech.com/data-capability/certifications)
 

--- a/data_learning_paths/data_101_core.md
+++ b/data_learning_paths/data_101_core.md
@@ -1,0 +1,44 @@
+# Data-101: An introduction to big data in Made Tech (basic tutorial)
+
+Welcome to the data-101 intro section!
+
+You can find the core learning path below to introduce you to some core data engineering concepts, this is a series of concise modules aiming to take an engineer with no data experience to feeling competent when presented with a data focussed project.
+
+To expand upon the core learning modules please check out the learning objectives folder where you can see some of the key learning objectives for each data engineer level, and resources to help you achieve those learning objectives.
+
+![Learning pathway diagram](https://github.com/madetech/data-101/blob/main/images/learningpathway.png?raw=true)
+
+# Core
+
+## Python
+ - :snake: [Python, pip, pyenv](../modules/core/Python.md)
+ - :satellite: [API Frameworks - Flask, fastAPI, Django](../modules/core/ApiFrameworks.md)
+
+### Modules
+ - :panda_face: [Pandas - Introduction to data loading & transformations](../modules/core/Python%20modules/Pandas.md)
+ - :earth_africa: [GeoPandas - Plotting spatial data](../modules/core/Python%20modules/geopandas.md)
+
+## Spark
+ - :sparkler: [Spark - Putting the **big** in *big data*](../modules/core/Spark.md)
+
+
+# Supplementary learning
+
+- :scream_cat: [SQL](../modules/supplementary/SQL.md)
+- :computer: [Terraform](../modules/supplementary/Terraform.md)
+- :floppy_disk: [Databases](../modules/supplementary/Databases.md)
+
+# Guides
+ - :robot: [Machine Learning Workflow: A guide for DMs](guides/machine_learning_workflow.md)
+ - :book: [Juypter Notebook Setup](guides/jupyter_setup.md)
+ - :pencil: [List of tooling](guides/tooling.md)
+ - :cat2: [Sphinx setup instructions](guides/sphinx_setup.md)
+ - :memo: [AWS Glue Features](guides/AWS_Glue_Features.md)
+ - :guardsman: [AWS TF Permissions](guides/aws_tf_permissions.md)
+ - :bookmark: [Poetry with Pyenv](guides/pyenv.md) 
+
+
+## Contributing to data-101
+We welcome and encourage all contributions! This resource is built by the COP-data community for the COP-data community.
+Please submit contributions via pull request.
+Any questions can be posted to [COP-data](https://madetechteam.slack.com/archives/C01PTEPED6G)


### PR DESCRIPTION
Review of README (Landing page) to work only as a summary of content instead of starting content itself.

+ Redirect Certifications to google site certs page to maintain it in a single place.

+ Flag possibility of content being outdated and encourage users to send PR whenever they identify it. 